### PR TITLE
Fix: Explicitly scope MSG_APP_REQUEST_DOWNLOAD

### DIFF
--- a/DownloadProgressView.cpp
+++ b/DownloadProgressView.cpp
@@ -426,7 +426,7 @@ DownloadProgressView::MessageReceived(BMessage* message)
 		}
 		case RESTART_DOWNLOAD:
 		{
-			BMessage request(MSG_APP_REQUEST_DOWNLOAD);
+			BMessage request(BrowserApp::MSG_APP_REQUEST_DOWNLOAD);
 			request.AddString("url", fURL);
 			if (fPath.InitCheck() == B_OK)
 				request.AddString("suggested_filename", fPath.Leaf());


### PR DESCRIPTION
Explicitly scope MSG_APP_REQUEST_DOWNLOAD in DownloadProgressView.cpp to ensure compiler recognition following previous fixes.